### PR TITLE
GDIオブジェクトリークを修正

### DIFF
--- a/EpgDataCap_Bon/EpgDataCap_Bon/EpgDataCap_BonDlg.cpp
+++ b/EpgDataCap_Bon/EpgDataCap_Bon/EpgDataCap_BonDlg.cpp
@@ -23,6 +23,7 @@ BOOL CEpgDataCap_BonDlg::disableKeyboardHook = FALSE;
 CEpgDataCap_BonDlg::CEpgDataCap_BonDlg()
 	: m_hWnd(NULL)
 	, m_hKeyboardHook(NULL)
+	, m_hDlgBgBrush(NULL)
 {
 	HMODULE hModule = GetModuleHandle(NULL);
 	HRESULT (WINAPI* pfnLoadIconMetric)(HINSTANCE,PCWSTR,int,HICON*) =
@@ -1251,15 +1252,20 @@ INT_PTR CALLBACK CEpgDataCap_BonDlg::DlgProc(HWND hDlg, UINT uMsg, WPARAM wParam
 		pSys = (CEpgDataCap_BonDlg*)lParam;
 		pSys->m_hWnd = hDlg;
 		pSys->m_hKeyboardHook = SetWindowsHookEx(WH_KEYBOARD, KeyboardProc, NULL, GetCurrentThreadId());
+		pSys->m_hDlgBgBrush = CreateSolidBrush(RGB(253, 253, 253));
 		return pSys->OnInitDialog();
 	// ダイヤログの背景色を白に変更
 	case WM_CTLCOLORDLG:
-		return (INT_PTR) CreateSolidBrush(RGB(253, 253, 253));
+		return (INT_PTR) pSys->m_hDlgBgBrush;
 	// コントロールの背景色を白に変更
 	case WM_CTLCOLORSTATIC:
 		SetBkMode(((HDC) wParam), TRANSPARENT);
-		return (INT_PTR) CreateSolidBrush(RGB(253, 253, 253));
+		return (INT_PTR) pSys->m_hDlgBgBrush;
 	case WM_NCDESTROY:
+		if( pSys->m_hDlgBgBrush ){
+			DeleteBrush(pSys->m_hDlgBgBrush);
+			pSys->m_hDlgBgBrush = NULL;
+		}
 		UnhookWindowsHookEx(pSys->m_hKeyboardHook);
 		pSys->m_hWnd = NULL;
 		break;

--- a/EpgDataCap_Bon/EpgDataCap_Bon/EpgDataCap_BonDlg.h
+++ b/EpgDataCap_Bon/EpgDataCap_Bon/EpgDataCap_BonDlg.h
@@ -52,6 +52,7 @@ protected:
 protected:
 	HWND m_hWnd;
 	HHOOK m_hKeyboardHook;
+	HBRUSH m_hDlgBgBrush;
 	HICON m_hIcon;
 	HICON m_hIcon2;
 


### PR DESCRIPTION
`CreateSolidBrush()`で作られたブラシが漏れているようです。
タスクマネージャーの「GDIオブジェクト」の項目をみると、EpgDataCap_Bonのそれが1秒に数個ずつ増え続けるはずです。
今のWindowsならシステムを巻き込むことはないと思いますが、アプリが最大確保できるGDIオブジェクトは通常10000個なので、ウィンドウ表示状態なら1時間ほどでEpgDataCap_Bonがクラッシュするか、挙動がおかしくなると思います。
